### PR TITLE
Fix previous_output(rt) and add test

### DIFF
--- a/src/default_storage.jl
+++ b/src/default_storage.jl
@@ -131,9 +131,10 @@ function Salsa._previous_output_internal(
     derived_key, args = key, key.args
 
     previous_output = nothing
+    RT = Any
 
     @lock storage.lock begin
-        cache = get_map_for_key(storage, derived_key)
+        cache = get_map_for_key(storage, derived_key, RT)
         if haskey(cache, args)
             previous_output = getindex(cache, args)
         end

--- a/src/runtime_tracing.jl
+++ b/src/runtime_tracing.jl
@@ -95,5 +95,10 @@ end
 
 function previous_output(rt::_TracingRuntime)
     dependency_key = trace(rt).call_stack.dp
-    return _unwrap_salsa_value(rt, _previous_output_internal(rt, dependency_key))
+    maybe_previous_value = _previous_output_internal(rt, dependency_key)
+    if maybe_previous_value === nothing
+        return nothing
+    else
+        return _unwrap_salsa_value(rt, maybe_previous_value)
+    end
 end

--- a/test/test_salsa.jl
+++ b/test/test_salsa.jl
@@ -427,8 +427,33 @@ end
 #     @test sum_all_ranges(rt) === sum(1:N) * I
 # end
 
+@testitem "Test previous_output" setup=[SalsaSetup] begin
+    using .SalsaSetup: new_test_rt
 
+    @declare_input n(s)::Int
 
+    @derived function sumrange(s)::Tuple{Int, Int}
+        prev_value = Salsa.previous_output(s)
+        cur_n = n(s)
+        reuse_prev = prev_value !== nothing && prev_value[2] < cur_n
+        result = reuse_prev ? prev_value[1] : 0
+        prev_n = reuse_prev ? prev_value[2] : 0
+        for x in (prev_n + 1):cur_n
+            result += x
+        end
+        return result, cur_n
+    end
+
+    rt = new_test_rt()
+    set_n!(rt, 1)
+    sumrange(rt) == 1
+
+    set_n!(rt, 3)
+    sumrange(rt) == 6
+
+    set_n!(rt, 1)
+    sumrange(rt) == 1
+end
 
 # NOTE: This test is testing internal aspects of the package, not the public API.
 @testitem "Growing the trace pool freelist" setup=[SalsaSetup] begin


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/Salsa.jl/issues/41

It looks like this was introduced in one of the mega-PRs from RelationalAI. Possibly this commit https://github.com/julia-vscode/Salsa.jl/commit/3841e5bdd9d2fbe8999b54676d5e4959da75cc0d was meant to fix things. As far as I can see the commented out code there was the actual fix.