### PR TITLE
Bound environment activation in CI

### DIFF
--- a/.github/workflows/juliaci.yml
+++ b/.github/workflows/juliaci.yml
@@ -13,6 +13,11 @@ jobs:
       include-all-compatible-minor-versions: true
       include-rc-versions: true
       testitem-timeout: 120
+      # Diagnostic, not a preference. Four Windows legs of run 32597222176 went silent with
+      # three items still pending and burned six hours each until GitHub's job limit; with
+      # activation unbounded, a test process that dies or stalls while starting up is waited
+      # on forever and nothing is logged. This arms the deadline so the leg says so instead.
+      activation-timeout: 300
     permissions: write-all
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
**Diagnostic PR for the six-hour CI hangs — its purpose is the CI run it triggers.**

Four Windows legs of [run 32597222176](https://github.com/julia-vscode/Salsa.jl/actions/runs/32597222176) went silent and burned ~6 h each until GitHub's job limit killed them. On `windows-latest 1.12.7~x64` the last output was at 21:56:28 and nothing followed until the cancellation at 03:47:39. Three items — `Simple API Usage`, `usage`, `macro usage corner cases` — had never started, and were reported `skipped` only because the cancellation arrived.

Those are exactly the three items that segfault inside LLVM's machine scheduler on Julia ≥1.12 on every non-Windows platform. Linux and macOS report the crash and finish; Windows goes quiet.

## Why nothing caught it

`activation_timeout_seconds` defaults to `nothing` in all three layers — `TestItemController` (`testitemcontroller.jl:114`), `TestSession` (`TestItemRuns/src/session.jl:327`) and juliati (`TestItemApp/src/cli.jl:129`) — and this workflow left `activation-timeout` empty. The machinery exists and is good: `testitemcontroller.jl:2384-2409` arms a deadline `CancellationTokenSource` and warns `"Environment activation timed out"` with the process id and elapsed time. With `nothing` it is simply never armed, so a process that dies or stalls while activating is waited on forever with nothing logged.

The existing `testitem-timeout: 120` does not help here — a per-item deadline only applies to an item that has *started*, and these three never did. That is also why it did not save the original run.

## What this PR is for

One line, `activation-timeout: 300`. Both outcomes are useful:

- **The deadline fires** → confirmed. Unbounded activation is the wedge, and the real fix is about the defaults and about what the controller does with the items that process still owed.
- **It still hangs** → activation is not where it is stuck, and the investigation moves to the reactor with a debug trace.

Either way the Windows legs stop costing six hours. Happy to close this unmerged once it has told us which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)